### PR TITLE
Add common issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: status/need-triage, type/bug
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+<!--- Make sure to follow the [Contribution Guidelines](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md), -->
+<!--- notably for [security-related issues](https://pivotal.io/security) -->
+<!-- Questions should be asked on [Gitter](https://gitter.im/reactor/reactor) or [StackOverflow](https://stackoverflow.com/questions/tagged/project-reactor). -->
+
+## Expected Behavior
+<!--- Tell us what you think should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug, eg. a unit test. Include code to reproduce, if relevant -->
+```java
+@Test
+public void repoCase() {
+
+}
+```
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug. -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+<!--- Especially, always include the version(s) of Reactor library/libraries you used -->
+* Reactor version(s) used:
+* Other relevant libraries versions (eg. `netty`, ...):
+* JVM version (`javar -version`):
+* OS and version (eg `uname -a`):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,20 +7,21 @@ assignees: ''
 
 ---
 
-<!--- Provide a general summary of the issue in the Title above -->
-<!--- Make sure to follow the [Contribution Guidelines](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md), -->
-<!--- notably for [security-related issues](https://pivotal.io/security) -->
-<!-- Questions should be asked on [Gitter](https://gitter.im/reactor/reactor) or [StackOverflow](https://stackoverflow.com/questions/tagged/project-reactor). -->
+ > :point_up: :+1: Provide a general summary of the issue in the Title above
+ >
+ > :warning: Make sure to follow the [Contribution Guidelines](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md),
+ > notably for [security-related issues](https://pivotal.io/security) and [questions](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md#question-do-you-have-a-question)
 
 ## Expected Behavior
-<!--- Tell us what you think should happen -->
+> :point_right: Tell us what you think should happen
 
 ## Actual Behavior
-<!--- Tell us what happens instead of the expected behavior -->
+> :point_right: Tell us what happens instead of the expected behavior
 
 ## Steps to Reproduce
-<!--- Provide a link to a live example, or an unambiguous set of steps to -->
-<!--- reproduce this bug, eg. a unit test. Include code to reproduce, if relevant -->
+> :point_right: Provide a link to a live example, or an unambiguous set of steps to
+> reproduce this bug, eg. a unit test. Include code to reproduce, if relevant
+
 ```java
 @Test
 public void repoCase() {
@@ -29,11 +30,13 @@ public void repoCase() {
 ```
 
 ## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug. -->
+> :point_right: Not obligatory, but you can suggest a fix/reason for the bug
 
 ## Your Environment
-<!--- Include as many relevant details about the environment you experienced the bug in -->
-<!--- Especially, always include the version(s) of Reactor library/libraries you used -->
+> :point_right: Include as many relevant details about the environment you experienced the bug in
+>
+> :+1: Especially, always include the version(s) of Reactor library/libraries you used
+
 * Reactor version(s) used:
 * Other relevant libraries versions (eg. `netty`, ...):
 * JVM version (`javar -version`):

--- a/.github/ISSUE_TEMPLATE/enhancement---suggestion.md
+++ b/.github/ISSUE_TEMPLATE/enhancement---suggestion.md
@@ -1,0 +1,25 @@
+---
+name: Enhancement / Suggestion
+about: Suggest an idea for this project
+title: ''
+labels: status/need-triage, type/enhancement
+assignees: ''
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+<!--- Make sure to follow the [Contribution Guidelines](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md), -->
+<!--- notably for [security-related issues](https://pivotal.io/security) -->
+<!-- Questions should be asked on [Gitter](https://gitter.im/reactor/reactor) or [StackOverflow](https://stackoverflow.com/questions/tagged/project-reactor). -->
+
+## Motivation
+<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+## Desired solution
+<!--- A clear and concise description of what you want to happen. -->
+
+## Considered alternatives
+<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Additional context
+<!--- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/enhancement---suggestion.md
+++ b/.github/ISSUE_TEMPLATE/enhancement---suggestion.md
@@ -7,19 +7,19 @@ assignees: ''
 
 ---
 
-<!--- Provide a general summary of the issue in the Title above -->
-<!--- Make sure to follow the [Contribution Guidelines](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md), -->
-<!--- notably for [security-related issues](https://pivotal.io/security) -->
-<!-- Questions should be asked on [Gitter](https://gitter.im/reactor/reactor) or [StackOverflow](https://stackoverflow.com/questions/tagged/project-reactor). -->
+ > :point_up: :+1: Provide a general summary of the issue in the Title above
+ >
+ > :warning: Make sure to follow the [Contribution Guidelines](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md),
+ > notably for [security-related issues](https://pivotal.io/security) and [questions](https://github.com/reactor/.github/blob/master/CONTRIBUTING.md#question-do-you-have-a-question)
 
 ## Motivation
-<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+> :point_right: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Desired solution
-<!--- A clear and concise description of what you want to happen. -->
+> :point_right: A clear and concise description of what you want to happen.
 
 ## Considered alternatives
-<!--- A clear and concise description of any alternative solutions or features you've considered. -->
+> :point_right: A clear and concise description of any alternative solutions or features you've considered.
 
 ## Additional context
-<!--- Add any other context or screenshots about the feature request here. -->
+> :point_right: Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,18 @@ The Reactor team appreciates your contributing effort! :heart: :heart: :heart:
 > Search Stack Overflow first; discuss if necessary
 
 If you're unsure why something isn't working or wondering if there is a better
-way of doing it please check on Stack Overflow first and if necessary start
-a discussion. Use the [`project-reactor`](https://stackoverflow.com/questions/tagged/project-reactor) tag for that purpose.
+way of doing it please check on **Stack Overflow** first and if necessary start
+a discussion. Use relevant tags among the ones we monitor for that purpose:
+ - [`reactor-netty`](https://stackoverflow.com/questions/tagged/reactor-netty) for specific reactor-netty questions
+ - [`project-reactor`](https://stackoverflow.com/questions/tagged/project-reactor) for generic reactor questions
 
-If you prefer real-time discussion, we also have a [Gitter channel](https://gitter.im/reactor/reactor).
+If you prefer real-time discussion, we also have a few **Gitter channels**:
+ - [`reactor`](https://gitter.im/reactor/reactor) is the historic most active one, where most of the community can help
+ - [`reactor-core`](https://gitter.im/reactor/reactor-core) is intended for more advanced pinpointed discussions around the inner workings of the library
+ - [`reactor-netty`](https://gitter.im/reactor/reactor-netty) is intended for netty-specific questions
+
+Refer to each project's README for potential other sources of information.
+
 
 ## :beetle: Did you find a bug?
 


### PR DESCRIPTION
Now that we have common labels and a centralized `CONTRIBUTING.md`, we can probably work out a common duo of issue templates that can be used across most projects.