### PR TITLE
Fix `javar` typo in issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,5 +43,5 @@ void reproCase() {
 
 * Reactor version(s) used:
 * Other relevant libraries versions (eg. `netty`, ...):
-* JVM version (`javar -version`):
+* JVM version (`java -version`):
 * OS and version (eg `uname -a`):


### PR DESCRIPTION
This PR fixes a typo in the issue template for bug reports.