### PR TITLE
Explicit deprecation policy in SUPPORT.md, lengthen deprecation cycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Links to eg. create issues point to `reactor/reactor-core` repository. Amend thi
 Start here:
 
  - [Do you have a question?](#question-do-you-have-a-question)
+ - [Deprecation policy](#recycle-our-policy-on-deprecations)
  - [Did you find a bug?](#beetle-did-you-find-a-bug)
  - [Did you write a patch that fixes a bug?](#wrench-did-you-write-a-patch-that-fixes-a-bug)
  - [Do you intend to add a new feature or change an existing one?](#mag-do-you-intend-to-add-a-new-feature-or-change-an-existing-one)
@@ -36,6 +37,24 @@ If you prefer real-time discussion, we also have a few **Gitter channels**:
 
 Refer to each project's README for potential other sources of information.
 
+We generally discourage opening GitHub issues for questions, in favor of the two channels above.
+
+## :recycle: Our policy on **deprecations**
+
+When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
+
+ - deprecations introduced in version `A`.`B`.`0` will be removed **no sooner than** version `A`.**`B+1`**.`0`
+ - deprecations introduced in version `A`.`B`.`1+` will be removed **no sooner than** version `A`.**`B+2`**.`0`
+ - we'll strive to mention the following in the deprecation javadoc:
+   - target minimum version for removal
+   - pointers to replacements for the deprecated method
+   - version in which method was deprecated
+
+> This policy is officially in effect as of January 20201.
+
+Note that deprecation removal targets are not a hard commitment, and the deprecated methods **could live on further than these minimum target GA versions** (ie. only the most problematic deprecated methods will be removed aggressively).
+
+:warning: That said, deprecated code that has outlived its minimum removal target version may be removed in any subsequent release (including patch releases, aka service releases) without further notice. So users should still strive to update their code as early as possible.
 
 ## :beetle: Did you find a bug?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
    - pointers to replacements for the deprecated method
    - version in which method was deprecated
 
-> This policy is officially in effect as of January 20201.
+> This policy is officially in effect as of January 2021.
 
 Note that deprecation removal targets are not a hard commitment, and the deprecated methods **could live on further than these minimum target GA versions** (ie. only the most problematic deprecated methods will be removed aggressively).
 
@@ -323,4 +323,3 @@ To learn more about these techniques, like `git rebase --interactive --autosquas
 atomic commit, in addition to the man pages for git.
 The [Rewriting History section of Pro Git](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
 provides a good overview about these tools.
-

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -28,7 +28,7 @@ When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
    - pointers to replacements for the deprecated method
    - version in which method was deprecated
 
-> This policy is officially in effect as of January 20201.
+> This policy is officially in effect as of January 2021.
 
 Note that deprecation removal targets are not a hard commitment, and the deprecated methods **could live on further than these minimum target GA versions** (ie. only the most problematic deprecated methods will be removed aggressively).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -16,3 +16,20 @@ If you prefer real-time discussion, we also have a few **Gitter channels**:
 Refer to each project's README for potential other sources of information.
 	
 We generally discourage opening GitHub issues for questions, in favor of the two channels above.
+
+## :recycle: Our policy on **deprecations**
+
+When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
+
+ - deprecations introduced in version `A`.`B`.`0` will be removed **no sooner than** version `A`.**`B+1`**.`0`
+ - deprecations introduced in version `A`.`B`.`1+` will be removed **no sooner than** version `A`.**`B+2`**.`0`
+ - we'll strive to mention the following in the deprecation javadoc:
+   - target minimum version for removal
+   - pointers to replacements for the deprecated method
+   - version in which method was deprecated
+
+> This policy is officially in effect as of January 20201.
+
+Note that deprecation removal targets are not a hard commitment, and the deprecated methods **could live on further than these minimum target GA versions** (ie. only the most problematic deprecated methods will be removed aggressively).
+
+:warning: That said, deprecated code that has outlived its minimum removal target version may be removed in any subsequent release (including patch releases, aka service releases) without further notice. So users should still strive to update their code as early as possible.


### PR DESCRIPTION
We hope that a less aggressive removal timeframe and an explicit policy
will help downstream projects which use deprecated methods upgrade.