### PR TITLE
updated support timelines and deprecation policies

### DIFF
--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -31,11 +31,16 @@ We generally discourage opening GitHub issues for questions, in favor of the two
 
 = Our policy on **deprecations**
 
-When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
+When dealing with deprecations, given a version `A.B.C` (e.g. 2020.0.1), we'll ensure
+that:
 
-* deprecations introduced in version `A`.`B`.`x` will be removed **no sooner than** in
-version released near or after the end of commercial support for `A`.`B`.`x` line or
-any prior lines supported longer than `A`.`B.`x` line
+* deprecations introduced in release train `A`.`B`.`0` will be removed **no sooner
+than** in release train released near or after the end of commercial support for `A-1`.`B`.`x`
+release train or any prior release trains supported longer than `A-1`.`B`.`x` release
+train
+* deprecations introduced in release train `A`.`B`.`x` will be removed **no sooner than** in
+release train released near or after the end of commercial support for `A`.`B`.`x` release
+train or any release trains supported longer than `A`.`B`.`x` release train
 * we'll strive to mention the following in the deprecation javadoc:
 ** target minimum version for removal
 ** pointers to replacements for the deprecated method

--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -33,7 +33,9 @@ We generally discourage opening GitHub issues for questions, in favor of the two
 
 When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
 
-* deprecations introduced in version `A`.`B`.`x` will be removed **no sooner than** in version released near or after the end of commercial support for `A`.`B`.`x` line
+* deprecations introduced in version `A`.`B`.`x` will be removed **no sooner than** in
+version released near or after the end of commercial support for `A`.`B`.`x` line or
+any prior lines supported longer than `A`.`B.`x` line
 * we'll strive to mention the following in the deprecation javadoc:
 ** target minimum version for removal
 ** pointers to replacements for the deprecated method

--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -41,10 +41,11 @@ any prior lines supported longer than `A`.`B.`x` line
 ** pointers to replacements for the deprecated method
 ** version in which method was deprecated
 
-TIP: If deprecation was introduced in 2020.0.12 release BOM, it could be removed not
-earlier than 2026-12-31 which is the end of commercial support for the 2020.0.x line.
-That means that only the iteration released in 2026 could safely remove in potential
-2026.0.x release BOM
+TIP: If deprecation was introduced in 2022.0.12 release BOM, it could be removed not
+earlier than 2026-12-31 since that is the end of commercial support for the 2020.0.x
+line which has longer support than 2022.0.x line.
+That means that only the iteration released in 2026 or later could safely remove given
+deprecations.
 
 TIP: This policy is officially in effect as of January 2024, for all modules in `2020.0` BOMs and newer release trains.
 

--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -33,14 +33,16 @@ We generally discourage opening GitHub issues for questions, in favor of the two
 
 When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
 
- * deprecations introduced in version `A`.`B`.`0` will be removed **no sooner than** version `A`.**`B+1`**.`0`
- * deprecations introduced in version `A`.`B`.`1+` will be removed **no sooner than** version `A`.**`B+2`**.`0`
- * we'll strive to mention the following in the deprecation javadoc:
-  ** target minimum version for removal
-  ** pointers to replacements for the deprecated method
-  ** version in which method was deprecated
+* deprecations introduced in version `A`.`B`.`x` will be removed **no sooner than** end of commercial support for `A`.`B`.`x` line
+* we'll strive to mention the following in the deprecation javadoc:
+** target minimum version for removal
+** pointers to replacements for the deprecated method
+** version in which method was deprecated
 
-TIP: This policy is officially in effect as of January 2021, for all modules in `2020.0` BOMs and newer release trains, as well as `Dysprosium` releases after `Dysprosium-SR15`.
+TIP: If deprecation was introduced in 2020.0.12 release BOM, it could be removed not
+earlier than 2026-12-31 which is the end of commercial support for the 2020.0.x line.
+
+TIP: This policy is officially in effect as of January 2023, for all modules in `2020.0` BOMs and newer release trains.
 
 NOTE: Deprecation removal targets are not a hard commitment, and the deprecated methods **could live on further than these minimum target GA versions** (ie. only the most problematic deprecated methods will be removed aggressively).
 
@@ -51,11 +53,13 @@ WARNING: That said, deprecated code that has outlived its minimum removal target
 The following table summarises the development status of the various Reactor release trains:
 
 |=======
-| Version                                                | Supported
+| Version                                                | Initial Release | End of Support            | End of Commercial Support*
 
-| 2022.0.x (core 3.5.x, netty 1.1.x)                     | {supported}
-| 2020.0.x (codename Europium) (core 3.4.x, netty 1.0.x) | {supported}
-| Dysprosium Train (core 3.3.x, netty 0.9.x)             | {unsupported}
-| Califonium and below (core < 3.3, netty < 0.9)         | {unsupported}
-| Reactor 1.x and 2.x Generations                        | {unsupported}
+| 2023.0.x (core 3.6.x, netty 1.1.x)                     | 2023.11.14      | 2025-08-31 {supported}    | 2026-12-31 {supported}
+| 2022.0.x (core 3.5.x, netty 1.1.x)                     | 2022.11.08      | 2024-08-31 {supported}    | 2025-12-31 {supported}
+| 2020.0.x (codename Europium) (core 3.4.x, netty 1.0.x) | 2020.10.26      | 2024-12-31 {supported}    | 2026-12-31 {supported}
 |=======
+
+NOTE:  *About commercial support* *(***)*:
+       This page shows the current state of project releases and does not define the
+commercial support policy. Please refer to the https://tanzu.vmware.com/spring-runtime[official support policy] for more information.

--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -42,7 +42,7 @@ When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
 TIP: If deprecation was introduced in 2020.0.12 release BOM, it could be removed not
 earlier than 2026-12-31 which is the end of commercial support for the 2020.0.x line.
 
-TIP: This policy is officially in effect as of January 2023, for all modules in `2020.0` BOMs and newer release trains.
+TIP: This policy is officially in effect as of January 2024, for all modules in `2020.0` BOMs and newer release trains.
 
 NOTE: Deprecation removal targets are not a hard commitment, and the deprecated methods **could live on further than these minimum target GA versions** (ie. only the most problematic deprecated methods will be removed aggressively).
 

--- a/SUPPORT.adoc
+++ b/SUPPORT.adoc
@@ -33,7 +33,7 @@ We generally discourage opening GitHub issues for questions, in favor of the two
 
 When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
 
-* deprecations introduced in version `A`.`B`.`x` will be removed **no sooner than** end of commercial support for `A`.`B`.`x` line
+* deprecations introduced in version `A`.`B`.`x` will be removed **no sooner than** in version released near or after the end of commercial support for `A`.`B`.`x` line
 * we'll strive to mention the following in the deprecation javadoc:
 ** target minimum version for removal
 ** pointers to replacements for the deprecated method
@@ -41,6 +41,8 @@ When dealing with deprecations, given a version `A.B.C`, we'll ensure that:
 
 TIP: If deprecation was introduced in 2020.0.12 release BOM, it could be removed not
 earlier than 2026-12-31 which is the end of commercial support for the 2020.0.x line.
+That means that only the iteration released in 2026 could safely remove in potential
+2026.0.x release BOM
 
 TIP: This policy is officially in effect as of January 2024, for all modules in `2020.0` BOMs and newer release trains.
 


### PR DESCRIPTION
This PR sets support timelines for OSS as well as for commercial support of specific release trains. Primarily support is aligned with spring-framework support timelines.


Also, this PR adjust the overall deprecation policy to follow the support timelines. The goal of deprecation policy add more time for specific deprecation to be in place.