### PR TITLE
Fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'triage/bug:question:'
+labels: status/need-triage, type/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -2,7 +2,7 @@
 name: Documentation Issue
 about: Suggest an improvement to the documentation (javadoc, reference doc...)
 title: ''
-labels: 'triage/documentation:question:'
+labels: status/need-triage, type/documentation
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement---suggestion.md
+++ b/.github/ISSUE_TEMPLATE/enhancement---suggestion.md
@@ -2,7 +2,7 @@
 name: Enhancement / Suggestion
 about: Suggest an idea for this project
 title: ''
-labels: 'triage/enhancement:question:'
+labels: status/need-triage, type/enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
The current ISSUE templates are using non-existing and invalid labels:

- .github/ISSUE_TEMPLATE/bug_report.md: `labels: 'triage/bug:question:`
- .github/ISSUE_TEMPLATE/documentation_issue.md: `labels: triage/documentation:question:`
- .github/ISSUE_TEMPLATE/enhancement---suggestion.md: `labels: triage/enhancement:question:`

fixing the above labels to existing ones will allow to prepare removal of reactorbot webhook, which was used so far to setup default issue labels:

- .github/ISSUE_TEMPLATE/bug_report.md: `labels: status/need-triage, type/bug`
- .github/ISSUE_TEMPLATE/documentation_issue.md: `labels: status/need-triage, type/documentation`
- .github/ISSUE_TEMPLATE/enhancement---suggestion.md: `status/need-triage, type/enhancement`

notes: reactor-core and reactor-netty are using `status/need-triage, type/bug, type/documentation, type/enhancement` labels, but `status/need-triage` label is missing in some other repos like reactor-pool, reactor-kafka, so we need to also create this missing label in such repos.